### PR TITLE
本番環境のビルド高速化&メモリ節約

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./src:/root/src
-      - /root/.gradle
+      - gradle-cache:/root/.gradle:cached
     env_file:
       - .env
+
+volumes:
+  gradle-cache:
+    driver: local
+

--- a/run-bot.sh
+++ b/run-bot.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-docker-compose run -e JAVA_HOME=/root/.sdkman/candidates/java/current base ./gradlew run
+docker-compose run -e JAVA_HOME=/root/.sdkman/candidates/java/current base ./gradlew --no-daemon run
 


### PR DESCRIPTION
- /root/.gradleのキャッシュ化
- gradle daemonを起動しないようにしてメモリ節約